### PR TITLE
Character/ranged revamp

### DIFF
--- a/Assets/Animations/Player/Player.controller
+++ b/Assets/Animations/Player/Player.controller
@@ -81,6 +81,7 @@ AnimatorStateMachine:
   m_AnyStateTransitions:
   - {fileID: -470527259138685383}
   - {fileID: 4826202920789927337}
+  - {fileID: -1797627917331694709}
   m_EntryTransitions: []
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []
@@ -89,6 +90,31 @@ AnimatorStateMachine:
   m_ExitPosition: {x: 800, y: 120, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
   m_DefaultState: {fileID: -6222386901832104359}
+--- !u!1101 &-1797627917331694709
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: die
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 8931791265567445092}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &-845355191606272426
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -153,6 +179,12 @@ AnimatorController:
     m_Controller: {fileID: 0}
   - m_Name: isMoving
     m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
+  - m_Name: die
+    m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0

--- a/Assets/Prefabs/Weapons/Test/Bullet.prefab
+++ b/Assets/Prefabs/Weapons/Test/Bullet.prefab
@@ -140,9 +140,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _Speed: 12.5
-  _Acceleration: 0
   _ProjectileDamage: 1
   _ProjectileType: 0
+  _FriendlyLayers:
+    serializedVersion: 2
+    m_Bits: 1024
+  _EnemyLayers:
+    serializedVersion: 2
+    m_Bits: 2048
 --- !u!114 &-1371728370533433506
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Character/Components/Actions/Attacking/Melee/MeleeAttack.cs
+++ b/Assets/Scripts/Character/Components/Actions/Attacking/Melee/MeleeAttack.cs
@@ -40,14 +40,9 @@ public class MeleeAttack : CharacterComponent
 
                 var enemyHP = enemy.GetComponentInParent<Health>();
 
-                if (enemyHP)
-                {
-                    enemyHP.Damage(_AttackDamage);
-                }
-                else
-                {
-                    Debug.LogError("No Health Component found on Enemy");
-                }
+                if (!enemyHP) return;
+
+                enemyHP.Damage(_AttackDamage);
             }
         }
     }

--- a/Assets/Scripts/Character/Components/Weapons/Projectiles/Bone/BoneProjectile.cs
+++ b/Assets/Scripts/Character/Components/Weapons/Projectiles/Bone/BoneProjectile.cs
@@ -8,25 +8,4 @@ public class BoneProjectile : Projectile
         _ProjectileMovement = Direction * _Speed * Time.deltaTime;
         _ProjectileRigidBody2D.MovePosition(_ProjectileRigidBody2D.position + _ProjectileMovement);
     }
-
-    protected override void OnTriggerEnter2D(Collider2D other)
-    {
-        if(other.tag == "Enemy"){
-            CharacterHealth characterHealth = other.GetComponent<CharacterHealth>();
-            characterHealth.Damage(_ProjectileDamage);
-            _ReturnObjectToPool.DestroyObject();
-        }
-        
-        foreach (var tag in _TagsToAvoid.TagsToAvoidStrings)
-        {
-            if(other.tag == tag){
-                return;
-            }
-        }
-        if(other.tag == "Non Hitable") {
-            return;
-        }
-
-        _ReturnObjectToPool.DestroyObject();
-    }
 }

--- a/Assets/Scripts/Character/Components/Weapons/Projectiles/Projectile.cs
+++ b/Assets/Scripts/Character/Components/Weapons/Projectiles/Projectile.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -7,6 +8,8 @@ public class Projectile : MonoBehaviour
     [SerializeField] protected float _Speed = 0f;
     [SerializeField] protected float _ProjectileDamage = 1f;
     [SerializeField] protected ProjectileTypes _ProjectileType;
+    [SerializeField] private LayerMask _FriendlyLayers;
+    [SerializeField] private LayerMask _EnemyLayers;
 
     protected Collider2D _Collider2D;
     protected Rigidbody2D _ProjectileRigidBody2D;
@@ -15,8 +18,6 @@ public class Projectile : MonoBehaviour
     protected Character _ProjectileOwner;
     protected ReturnObjectToPool _ReturnObjectToPool;
 
-    protected LayerIgnore _LayersToIgnore;
-    protected TagsToAvoid _TagsToAvoid;
     private float _StartingSpeed;
 
     public Vector2 Direction { get; set; }
@@ -34,15 +35,12 @@ public class Projectile : MonoBehaviour
         _ProjectileRigidBody2D = GetComponent<Rigidbody2D>();
         _ProjectileSpriteRender = GetComponent<SpriteRenderer>();
         _Collider2D = GetComponent<Collider2D>();
-        _LayersToIgnore = GetComponent<LayerIgnore>();
-        _TagsToAvoid = GetComponent<TagsToAvoid>();
         _ReturnObjectToPool = GetComponent<ReturnObjectToPool>();
     }
 
     // Start is called before the first frame update
     protected virtual void Start()
     {
-        SetLayerCollisionIgnores();
         _StartingSpeed = _Speed;
     }
 
@@ -54,14 +52,6 @@ public class Projectile : MonoBehaviour
 
     protected virtual void FixedUpdate(){
         MoveProjectile();
-    }
-
-    protected virtual void SetLayerCollisionIgnores(){
-        if(_LayersToIgnore == null) return;
-        foreach (int item in _LayersToIgnore.LayersToIgnore)
-        {
-            Physics.IgnoreLayerCollision(gameObject.layer, item);
-        }
     }
 
     protected virtual void MoveProjectile(){
@@ -85,18 +75,24 @@ public class Projectile : MonoBehaviour
     }
 
     protected virtual void OnTriggerEnter2D(Collider2D other) {
-        // This will need to improve drastically.
-        if(_TagsToAvoid != null){
-            foreach (var tag in _TagsToAvoid.TagsToAvoidStrings)
-            {
-                if(other.tag == tag){
-                    return;
-                }
-            }
-            if(other.tag == "Non Hitable") {
-                return;
-            }
+        if (_FriendlyLayers == (_FriendlyLayers | (1 << other.gameObject.layer))) return;
+
+        if (_EnemyLayers == (_EnemyLayers | (1 << other.gameObject.layer)))
+        {
+            // allows overrides
+            DoEnemyCollision(other);
         }
+
+        _ReturnObjectToPool.DestroyObject();
+    }
+
+    protected virtual void DoEnemyCollision(Collider2D other)
+    {
+        var enemyHP = other.GetComponentInParent<CharacterHealth>();
+
+        if (!enemyHP || other.tag != "HitBox") return;
+
+        enemyHP.Damage(_ProjectileDamage);
     }
 
     protected virtual void OnTriggerStay2D(Collider2D collider){

--- a/Assets/Scripts/Character/Components/Weapons/Projectiles/Projectile.cs
+++ b/Assets/Scripts/Character/Components/Weapons/Projectiles/Projectile.cs
@@ -88,7 +88,7 @@ public class Projectile : MonoBehaviour
 
     protected virtual void DoEnemyCollision(Collider2D other)
     {
-        var enemyHP = other.GetComponentInParent<CharacterHealth>();
+        var enemyHP = other.GetComponentInParent<Health>();
 
         if (!enemyHP || other.tag != "HitBox") return;
 

--- a/Assets/Scripts/Character/Components/Weapons/Weapons/BoneThrow.cs
+++ b/Assets/Scripts/Character/Components/Weapons/Weapons/BoneThrow.cs
@@ -3,7 +3,8 @@ using System.Collections.Generic;
 using UnityEngine;
 
 public class BoneThrow : Weapon
-{   
+{
+    private int _SelfDamage = 1;
 
     protected override void UseWeapon()
     {
@@ -13,6 +14,13 @@ public class BoneThrow : Weapon
 
     private void SpawnProjectile(){
         GameObject pooledProjectile = _ObjectPooler.GetGameObjectFromPool();
+
+        var throwerHP = WeaponOwner.GetComponent<Health>();
+
+        if (throwerHP)
+        {
+            throwerHP.Damage(_SelfDamage);
+        }
 
         pooledProjectile.transform.position = _ProjectileSpawnPosition.position;
         pooledProjectile.SetActive(true);

--- a/Assets/Scripts/Shared/Objects/Health.cs
+++ b/Assets/Scripts/Shared/Objects/Health.cs
@@ -61,7 +61,7 @@ public class Health : MonoBehaviour
 
         float newHealth = _CurrentHealth - amount;
 
-        if (newHealth <= 0)
+        if (newHealth <= 0 && _CurrentHealth > 0)
         {
             _CurrentHealth = 0;
             Die();


### PR DESCRIPTION
In this PR I removed the the tag and layer ignore logic in favor of locally stored "friendly" and "enemy" layer variables.

This way is more condensed (no need to add ignores and search through a list of tags) and easier to read: 
![image](https://user-images.githubusercontent.com/16705858/156972326-c7d39c0f-0e57-4724-9fa4-24a55d2c50e4.png)
(note: multiple layers can be selected)

When a projectile collides with...
A friendly layer: the collision returns and the projectile keeps moving
An enemy layer: the colliding enemies HP is reduced by the projectile damage and the projectile is destroyed
Any other layer: the projectile is destroyed

Also added player self damage and death animations.